### PR TITLE
Switch on `importlib.resources`

### DIFF
--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -2,14 +2,14 @@ import operator
 import re
 from collections import defaultdict
 from functools import reduce
-from pathlib import Path
+from importlib.resources import files
 from typing import Callable, Optional, Tuple
 
 import numpy
 
 from ..compat import cupy, has_cupy_gpu
 
-PWD = Path(__file__).parent
+PWD = files(__package__)
 KERNELS_SRC = (PWD / "_custom_kernels.cu").read_text(encoding="utf8")
 KERNELS_LIST = [
     "backprop_clipped_linear<double>",


### PR DESCRIPTION
## Description

What's wrong with`__file__`? The assumption that you have files and subdirectories available is not correct. This approach doesn't work if executing code which is packed in a zip or a wheel, and it may be entirely out of the user's control whether or not your package gets extracted to a filesystem at all.

### Types of change

Switch on `importlib.resources.files` (Added in version Python 3.9.)

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
